### PR TITLE
Config creation/disposal changes

### DIFF
--- a/addons/godot_rl_agents/onnx/csharp/ONNXInference.cs
+++ b/addons/godot_rl_agents/onnx/csharp/ONNXInference.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace GodotONNX
 {
 	/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/ONNXInference/*'/>
-	public partial class ONNXInference : Node
+	public partial class ONNXInference : GodotObject
 	{
 
 		private InferenceSession session;
@@ -17,7 +17,7 @@ namespace GodotONNX
 		private string modelPath;
 		private int batchSize;
 
-		private static SessionOptions SessionOpt;
+		private SessionOptions SessionOpt;
 
 		//init function
 		/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Initialize/*'/>
@@ -25,8 +25,8 @@ namespace GodotONNX
 		{
 			modelPath = Path;
 			batchSize = BatchSize;
-			SessionOpt = SessionConfigurator.GetSessionOptions();
-			session = LoadModel(modelPath);
+            SessionOpt = SessionConfigurator.MakeConfiguredSessionOptions();
+            session = LoadModel(modelPath);
 
 		}
 		/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Run/*'/>

--- a/addons/godot_rl_agents/onnx/csharp/SessionConfigurator.cs
+++ b/addons/godot_rl_agents/onnx/csharp/SessionConfigurator.cs
@@ -16,91 +16,95 @@ namespace GodotONNX
 			CPU
 		}
 
-		private static SessionOptions options = new SessionOptions();
+        /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/GetSessionOptions/*'/>
+        public static SessionOptions MakeConfiguredSessionOptions()
+        {
+            SessionOptions sessionOptions = new();
+            SetOptions(sessionOptions);
+            return sessionOptions;
+        }
 
-		/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/GetSessionOptions/*'/>
-		public static SessionOptions GetSessionOptions()
-		{
-			options.LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING;
-			// see warnings
-			SystemCheck();
-			return options;
-		}
+        private static void SetOptions(SessionOptions sessionOptions)
+        {
+            sessionOptions.LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING;
+            ApplySystemSpecificOptions(sessionOptions);
+        }
 
-		/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/SystemCheck/*'/>
-		static public void SystemCheck()
-		{
-			//Most code for this function is verbose only, the only reason it exists is to track
-			//implementation progress of the different compute APIs.
+        /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/SystemCheck/*'/>
+        static public void ApplySystemSpecificOptions(SessionOptions sessionOptions)
+        {
+            //Most code for this function is verbose only, the only reason it exists is to track
+            //implementation progress of the different compute APIs.
 
-			//December 2022: CUDA is not working. 
+            //December 2022: CUDA is not working. 
 
-			string OSName = OS.GetName(); //Get OS Name
+            string OSName = OS.GetName(); //Get OS Name
 
-			//ComputeName ComputeAPI = ComputeCheck(); //Get Compute API
-			//                                         //TODO: Get CPU architecture
-			
-			//Linux can use OpenVINO (C#) on x64 and ROCm on x86 (GDNative/C++)
-			//Windows can use OpenVINO (C#) on x64
-			//TODO: try TensorRT instead of CUDA
-			//TODO: Use OpenVINO for Intel Graphics
+            //ComputeName ComputeAPI = ComputeCheck(); //Get Compute API
+            //                                         //TODO: Get CPU architecture
 
-			// Temporarily using CPU on all platforms to avoid errors detected with DML
-			ComputeName ComputeAPI = ComputeName.CPU;
+            //Linux can use OpenVINO (C#) on x64 and ROCm on x86 (GDNative/C++)
+            //Windows can use OpenVINO (C#) on x64
+            //TODO: try TensorRT instead of CUDA
+            //TODO: Use OpenVINO for Intel Graphics
 
-			//match OS and Compute API
-			GD.Print($"OS: {OSName} Compute API: {ComputeAPI}");
+            // Temporarily using CPU on all platforms to avoid errors detected with DML
+            ComputeName ComputeAPI = ComputeName.CPU;
 
-			options.AppendExecutionProvider_CPU(0);
+            //match OS and Compute API
+            GD.Print($"OS: {OSName} Compute API: {ComputeAPI}");
 
-			/*
-			switch (OSName)
-			{
-				case "Windows": //Can use CUDA, DirectML
-					if (ComputeAPI is ComputeName.CUDA)
-					{
-						//CUDA 
-						//options.AppendExecutionProvider_CUDA(0);
-						//options.AppendExecutionProvider_DML(0);
-					}
-					else if (ComputeAPI is ComputeName.DirectML)
-					{
-						//DirectML
-						//options.AppendExecutionProvider_DML(0);
-					}
-					break;
-				case "X11": //Can use CUDA, ROCm
-					if (ComputeAPI is ComputeName.CUDA)
-					{
-						//CUDA
-						//options.AppendExecutionProvider_CUDA(0);
-					}
-					if (ComputeAPI is ComputeName.ROCm)
-					{
-						//ROCm, only works on x86 
-						//Research indicates that this has to be compiled as a GDNative plugin
-						//GD.Print("ROCm not supported yet, using CPU.");
-						//options.AppendExecutionProvider_CPU(0);
-					}
-					break;
-				case "macOS": //Can use CoreML
-					if (ComputeAPI is ComputeName.CoreML)
-					{ //CoreML
-					  //TODO: Needs testing
-						//options.AppendExecutionProvider_CoreML(0);
-						//CoreML on ARM64, out of the box, on x64 needs .tar file from GitHub
-					}
-					break;
-				default:
-					GD.Print("OS not Supported.");
-					break;
-			}
-			*/
-		}
-		
+            // CPU is set by default without appending necessary
+            // sessionOptions.AppendExecutionProvider_CPU(0);
 
-		/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/ComputeCheck/*'/>
-		public static ComputeName ComputeCheck()
+            /*
+            switch (OSName)
+            {
+                case "Windows": //Can use CUDA, DirectML
+                    if (ComputeAPI is ComputeName.CUDA)
+                    {
+                        //CUDA 
+                        //sessionOptions.AppendExecutionProvider_CUDA(0);
+                        //sessionOptions.AppendExecutionProvider_DML(0);
+                    }
+                    else if (ComputeAPI is ComputeName.DirectML)
+                    {
+                        //DirectML
+                        //sessionOptions.AppendExecutionProvider_DML(0);
+                    }
+                    break;
+                case "X11": //Can use CUDA, ROCm
+                    if (ComputeAPI is ComputeName.CUDA)
+                    {
+                        //CUDA
+                        //sessionOptions.AppendExecutionProvider_CUDA(0);
+                    }
+                    if (ComputeAPI is ComputeName.ROCm)
+                    {
+                        //ROCm, only works on x86 
+                        //Research indicates that this has to be compiled as a GDNative plugin
+                        //GD.Print("ROCm not supported yet, using CPU.");
+                        //sessionOptions.AppendExecutionProvider_CPU(0);
+                    }
+                    break;
+                case "macOS": //Can use CoreML
+                    if (ComputeAPI is ComputeName.CoreML)
+                    { //CoreML
+                      //TODO: Needs testing
+                        //sessionOptions.AppendExecutionProvider_CoreML(0);
+                        //CoreML on ARM64, out of the box, on x64 needs .tar file from GitHub
+                    }
+                    break;
+                default:
+                    GD.Print("OS not Supported.");
+                    break;
+            }
+            */
+        }
+
+
+        /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/ComputeCheck/*'/>
+        public static ComputeName ComputeCheck()
 		{
 			string adapterName = Godot.RenderingServer.GetVideoAdapterName();
 			//string adapterVendor = Godot.RenderingServer.GetVideoAdapterVendor();


### PR DESCRIPTION
Changes to creation/disposal of the config. Previously with scene switching (making new instances of OnnxInference), the code was trying to configure a disposed instance of SessionOptions (since the instance was stored in a static field, the reference itself would stay after the object is freed), causing crashes. 

Removed the static references to config, this also allows every instance having its own config if needed in the future, and set the method names to make it clear that after these changes the SessionConfigurator is now generating new pre-configured config objects rather than retrieving a shared config.

A possible alternative would be to have one config instance that stays until Godot is closed, and then only dispose it at that time.